### PR TITLE
fix(CBI-545): date range proper hours

### DIFF
--- a/src/components/Card/input.tsx
+++ b/src/components/Card/input.tsx
@@ -422,6 +422,12 @@ function input(
                         ? field.value.map(v => typeof v === 'string' ? new Date(v) : v)
                         : field.value}
                     {...props}
+                    onChange={event => {
+                        if (event?.value?.[1]) {
+                            event.value[1].setHours(23, 59, 59, 999);
+                        }
+                        field.onChange(event);
+                    }}
                 />
             </Field>;
         case 'number': return <Field {...{label, error, inputClass}}>


### PR DESCRIPTION
Реших да го направя с текущия ден 23:59:59.999, пробвах и с setDate(getDate() + 1) както обсъждахме, но в такъв случай на календар UI-a се селектира винаги следващия ден, от този който юзъра избира.

Клик 2 пъти на 6ти Януари, селектира 6ти и 7ми.
Клик на 5ти Януари и на 6ти Януари, селектира 5, 6 и 7.