### PR TITLE
feat(CBI-1110): portal secondary title

### DIFF
--- a/src/components/App/App.stories.tsx
+++ b/src/components/App/App.stories.tsx
@@ -20,11 +20,11 @@ const Template: Story<Props & {dir?: 'rtl' | 'ltr', theme}> = ({dir: storyDir, t
     history.replaceState({}, '', '#');
     return <App
         portalName='test app'
+        extraTitle='secondary title'
         state={merge({}, state, {login: {language: {languageId: language}}})}
         theme={{
             ut: {
-                classes: {},
-                extraTitle: 'secondary title'
+                classes: {}
             },
             dir: storyDir || dir,
             language,

--- a/src/components/App/App.stories.tsx
+++ b/src/components/App/App.stories.tsx
@@ -23,7 +23,8 @@ const Template: Story<Props & {dir?: 'rtl' | 'ltr', theme}> = ({dir: storyDir, t
         state={merge({}, state, {login: {language: {languageId: language}}})}
         theme={{
             ut: {
-                classes: {}
+                classes: {},
+                extraTitle: 'secondary title'
             },
             dir: storyDir || dir,
             language,

--- a/src/components/App/App.types.ts
+++ b/src/components/App/App.types.ts
@@ -9,6 +9,7 @@ export interface Props extends StoreProps, React.HTMLAttributes<HTMLDivElement> 
     theme: Theme,
     customization?: boolean,
     portalName: string,
+    extraTitle?: string,
     devTool?: boolean,
     loginPage?: string,
     registrationPage?: string

--- a/src/components/App/__snapshots__/App.test.tsx.snap
+++ b/src/components/App/__snapshots__/App.test.tsx.snap
@@ -168,6 +168,11 @@ exports[`<App /> Basic equals snapshot 1`] = `
                 </li>
               </ul>
             </div>
+            <div
+              class="p-component text-lg mr-2 font-bold"
+            >
+              secondary title
+            </div>
             <button
               class="p-button p-component p-button-icon-only"
             >
@@ -532,6 +537,11 @@ exports[`<App /> BasicAR equals snapshot 1`] = `
                 </li>
               </ul>
             </div>
+            <div
+              class="p-component text-lg mr-2 font-bold"
+            >
+              عنوان ثانوي
+            </div>
             <button
               class="p-button p-component p-button-icon-only"
             >
@@ -895,6 +905,11 @@ exports[`<App /> BasicBG equals snapshot 1`] = `
                   </a>
                 </li>
               </ul>
+            </div>
+            <div
+              class="p-component text-lg mr-2 font-bold"
+            >
+              второ заглавие
             </div>
             <button
               class="p-button p-component p-button-icon-only"

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -14,14 +14,14 @@ import Component from '../Component';
 import { ComponentProps } from './App.types';
 import PageNotFound from './PageNotFound';
 
-const App: ComponentProps = ({middleware, reducers, theme: defaultTheme, devTool, portalName, customization, state, onDispatcher, loginPage, registrationPage}) => {
+const App: ComponentProps = ({middleware, reducers, theme: defaultTheme, devTool, portalName, extraTitle, customization, state, onDispatcher, loginPage, registrationPage}) => {
     const [theme, setTheme] = React.useState(defaultTheme);
     const setLanguage = React.useCallback(language => setTheme(prev => ({
         ...prev,
         language,
         dir: ['ar', 'arc', 'dv', 'fa', 'ha', 'he', 'khw', 'ks', 'ku', 'ps', 'ur', 'yi'].includes(language) ? 'rtl' : 'ltr'
     })), []);
-    const context = React.useMemo(() => ({portalName, devTool, customization, setLanguage}), [portalName, devTool, customization, setLanguage]);
+    const context = React.useMemo(() => ({portalName, devTool, customization, setLanguage, extraTitle}), [portalName, devTool, customization, setLanguage, extraTitle]);
     React.useEffect(() => {
         locale(theme?.language || 'en');
         theme?.languages && Object.entries(theme.languages).forEach(([language, options]) => addLocale(language, options));

--- a/src/components/Context/index.ts
+++ b/src/components/Context/index.ts
@@ -11,7 +11,8 @@ interface contextType {
     customization: boolean,
     portalName: string,
     devTool?: boolean,
-    setLanguage?: (language: string) => void
+    setLanguage?: (language: string) => void,
+    extraTitle?: string
 }
 
 const defaultContext: contextType = {

--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -55,11 +55,7 @@ const Portal: ComponentProps = ({ children }) => {
     const location = useLocation();
     const history = useHistory();
     const size = useWindowSize();
-    const {portalName: portalNameCtx, extraTitle: extraTitleCtx} = React.useContext(Context);
-    const {portalName, extraTitle} = React.useMemo(() => ({
-        portalName: ut?.portalName || portalNameCtx,
-        extraTitle: ut?.extraTitle || extraTitleCtx
-    }), [ut?.portalName, ut?.extraTitle, portalNameCtx, extraTitleCtx]);
+    const {portalName, extraTitle} = React.useContext(Context);
     const command = React.useCallback(({item}) => {
         if (item.component || item.tab) {
             dispatch({type: 'front.tab.show', ...item});

--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -55,7 +55,11 @@ const Portal: ComponentProps = ({ children }) => {
     const location = useLocation();
     const history = useHistory();
     const size = useWindowSize();
-    const {portalName} = React.useContext(Context);
+    const {portalName: portalNameCtx, extraTitle: extraTitleCtx} = React.useContext(Context);
+    const {portalName, extraTitle} = React.useMemo(() => ({
+        portalName: ut?.portalName || portalNameCtx,
+        extraTitle: ut?.extraTitle || extraTitleCtx
+    }), [ut?.portalName, ut?.extraTitle, portalNameCtx, extraTitleCtx]);
     const command = React.useCallback(({item}) => {
         if (item.component || item.tab) {
             dispatch({type: 'front.tab.show', ...item});
@@ -110,6 +114,7 @@ const Portal: ComponentProps = ({ children }) => {
                         <Text>{portalName}</Text>
                     </div>
                     <Menubar model={menuEnabled} className={classes[menuClass]} style={backgroundNone}/>
+                    {extraTitle ? <div className='p-component text-lg mr-2 font-bold'><Text>{extraTitle}</Text></div> : null}
                     {Switch ? <Switch /> : null}
                     <Menubar model={rightEnabled} className={classes[rightMenuClass]} style={backgroundNone}/>
                 </div>

--- a/src/components/Text/Text.mock.tsx
+++ b/src/components/Text/Text.mock.tsx
@@ -28,6 +28,7 @@ const translations = {
     bg: parse(`
         Dashboard=Табло
         test app=тест приложение
+        secondary title=второ заглавие
         Main=Главно
         Page 1=Страница 1
         Page 2=Страница 2
@@ -144,6 +145,7 @@ const translations = {
     ar: parse(`
         Dashboard=لوحة القيادة
         test app=تطبيق الاختبار
+        secondary title=عنوان ثانوي
         Main=رئيسي
         Page 1=صفحة 1
         Page 2=الصفحة 2

--- a/src/components/Theme/index.tsx
+++ b/src/components/Theme/index.tsx
@@ -54,9 +54,7 @@ export interface Theme {
             loginTop?: string,
             loginBottom?: string,
             labelRequired?: string,
-        },
-        portalName?: string,
-        extraTitle?: string
+        }
     },
     fontSize?: number;
     name?: string,

--- a/src/components/Theme/index.tsx
+++ b/src/components/Theme/index.tsx
@@ -56,6 +56,7 @@ export interface Theme {
             labelRequired?: string,
         },
         portalName?: string,
+        extraTitle?: string
     },
     fontSize?: number;
     name?: string,

--- a/src/components/test/index.tsx
+++ b/src/components/test/index.tsx
@@ -19,8 +19,7 @@ window.HTMLElement.prototype.scrollIntoView = function() {};
 export function render(children: React.ReactNode, initialStore: State = {}, language = undefined, middleware = undefined) : RenderResult {
     const theme = {
         ut: {
-            classes: {},
-            portalName: 'Administration Portal'
+            classes: {}
         }
     };
     const store = <DndProvider backend={HTML5Backend}>

--- a/src/components/test/index.tsx
+++ b/src/components/test/index.tsx
@@ -20,7 +20,7 @@ export function render(children: React.ReactNode, initialStore: State = {}, lang
     const theme = {
         ut: {
             classes: {},
-            portalName: 'Administration'
+            portalName: 'Administration Portal'
         }
     };
     const store = <DndProvider backend={HTML5Backend}>

--- a/src/components/test/wrap.tsx
+++ b/src/components/test/wrap.tsx
@@ -39,8 +39,7 @@ function Wrap({
         ut: {
             classes: {
                 labelRequired: classes.labelRequired
-            },
-            portalName: 'Administration'
+            }
         },
         dir
     };


### PR DESCRIPTION
Малко съм объркан защото portalName го има като тип и във theme и в context.

В context го подава App, а на App сякаш се подава от ut-portal/ready като там се чете от config или от portal.params.get:
https://github.com/softwaregroup-bg/ut-portal/blob/master/browser/portal/ready.js

Съответно ми се струва, че може би излишно го има като тип в темата?

В момента го направих ако има portalName или extraTitle в темата, те да са с предимство пред context-a.

Трябва ли да допълня ut-portal да чете extraTitle от config и portal.params.get?