### PR TITLE
fix(CBI-4799): allow btn label to be translated in editor toolbar

### DIFF
--- a/src/components/Editor/Editor.stories.tsx
+++ b/src/components/Editor/Editor.stories.tsx
@@ -11,6 +11,7 @@ import type { Props } from './Editor.types';
 import tree from '../test/tree';
 import document from '../test/document';
 import decorators from '../test/decorator';
+import {middleware} from '../Text/Text.mock';
 import useToast from '../hooks/useToast';
 import unauthenticated from '../test/unauthenticated';
 import type {UtError} from '../types';
@@ -23,7 +24,8 @@ const meta: Meta = {
     decorators,
     excludeStories: ['Template'],
     args: {
-        state: {}
+        state: {},
+        middleware: [middleware]
     }
 };
 export default meta;
@@ -469,4 +471,10 @@ Toolbar.args = {
             }]
         }
     }
+};
+
+export const ToolbarBG: StoryTemplate = Template.bind({});
+ToolbarBG.args = {
+    ...Toolbar.args,
+    lang: 'bg'
 };

--- a/src/components/Text/Text.mock.tsx
+++ b/src/components/Text/Text.mock.tsx
@@ -147,6 +147,8 @@ const translations = {
         User Type=Тип потребител
         Username=Потребителско име
         Documents=Документи
+
+        Browse=Разгледай
     `),
     ar: parse(`
         Dashboard=لوحة القيادة
@@ -252,6 +254,8 @@ const translations = {
         User Type=نوع المستخدم
         Username=اسم المستخدم
         Documents=وثائق
+
+        Browse=تصفح
     `)
 };
 /* spell-checker: enable */

--- a/src/components/prime/index.tsx
+++ b/src/components/prime/index.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import Component from '../Component';
 import Text from '../Text';
 import useTooltip from '../hooks/useTooltip';
+import useText from '../hooks/useText';
 import Permission from '../Permission';
 import {Props as PermissionProps} from '../Permission/Permission.types';
 import {confirmPopup as confirmPopupPrime} from 'primereact/confirmpopup';
@@ -137,11 +138,13 @@ export const Button = ({children, permission, confirm, onClick, tooltip, tooltip
         accept: () => onClick(event)
     }) : onClick(event), [onClick, confirm]);
     const tooltipProps = useTooltip({tooltip, tooltipOptions, reactTooltip});
+    const label = useText({text: props.label});
     const button = (
         <PrimeButton
             {...props}
             {...tooltipProps}
             onClick={handleClick}
+            label={label}
         >
             {children && (
                 <span className="p-button-label p-c">


### PR DESCRIPTION
not urgent as it can be worked around by passing title instead of label in the schema