### PR TITLE
fix(LS-92): do not remove lines if its single line

### DIFF
--- a/src/components/Json/lib.js
+++ b/src/components/Json/lib.js
@@ -177,6 +177,7 @@ export default function compare(current, previous) {
     }
     compareInner(current, previous);
     function removeConsecutiveEmptyLines(la) {
+        if (la.length === 1) return la;
         const lines = [];
         for (let i = 0; i < la.length - 1; i++) {
             if (la[i].empty && la[i + 1].empty) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,3 +32,4 @@ export { default as ScrollBox } from './ScrollBox';
 export { default as Store } from './Store';
 export { default as Text } from './Text';
 export { default as ThumbIndex } from './ThumbIndex';
+export { default as Json } from './Json';


### PR DESCRIPTION
If a single line is passed it doesn't enter the for loop, hence the lines remain empty array and nothing is shown to the user unless at least 2 lines are provided to the Json component.